### PR TITLE
fix spelling in error message

### DIFF
--- a/autoload/iced/message.vim
+++ b/autoload/iced/message.vim
@@ -3,7 +3,7 @@ set cpo&vim
 
 let s:messages = {
     \ 'auto_connect':      'Auto connecting...',
-    \ 'no_port_file':      '.nrepl-poort is not found.',
+    \ 'no_port_file':      '.nrepl-port is not found.',
     \ 'connect_error':     'Failed to connect.',
     \ 'not_connected':     'Not connected.',
     \ 'try_connect':       'Not connected. Try `:IcedConnect <port>`',


### PR DESCRIPTION
Looks like there was a misspelling since the file we should be looking for is called `.nrepl-port` I think.