### PR TITLE
force recent tools.namespace dep

### DIFF
--- a/bin/iced
+++ b/bin/iced
@@ -76,7 +76,7 @@ case "$1" in
             boot -i "(require 'cider.tasks)" -d nrepl:0.5.2 -d refactor-nrepl:2.4.0 -d cider/cider-nrepl:0.19.0-SNAPSHOT -d cider/piggieback:0.3.10 -d iced-nrepl:0.2.11 -- cider.tasks/add-middleware -m cider.nrepl/wrap-complete -m cider.nrepl/wrap-debug -m cider.nrepl/wrap-format -m cider.nrepl/wrap-info -m cider.nrepl/wrap-macroexpand -m cider.nrepl/wrap-ns -m cider.nrepl/wrap-out -m cider.nrepl/wrap-pprint -m cider.nrepl/wrap-pprint-fn -m cider.nrepl/wrap-spec -m cider.nrepl/wrap-test -m cider.nrepl/wrap-trace -m cider.nrepl/wrap-undef -m cider.piggieback/wrap-cljs-repl -m refactor-nrepl.middleware/wrap-refactor -m iced.nrepl/wrap-iced -- $OPTIONS repl
         elif [ $IS_CLOJURE_CLI -eq 1 ]; then
             echo_info "Clojure CLI project is detected"
-            clojure $OPTIONS -Sdeps "{:deps {iced-repl {:local/root \"${PROJECT_DIR}\"}}}" -m iced-repl
+            clojure $OPTIONS -Sdeps "{:deps {iced-repl {:local/root \"${PROJECT_DIR}\"} org.clojure/tools.namespace {:mvn/version \"0.3.0-alpha4\"}}}" -m iced-repl
         else
             echo_error 'Failed to detect clojure project'
             exit 1


### PR DESCRIPTION
Hi. Thanks for writing this clojure plugin for vim. It looks fantastic, and I'm planning to try using it for a while. I might find a few glitches on my own projects, and here's a small one I encountered. 

My project has a dependency on tools.namespace 0.2.11. (It's a deps.edn project.) It looks like `iced repl` needs 0.3.0. When I run `iced repl` on this project, it produced the following error:

```
჻ iced repl
\e[32mOK\e[m: \e[1mClojure CLI project is detected\e[m
Exception in thread "main" java.lang.RuntimeException: No such var: ns-find/sources-in-jar, compiling:(orchard/namespace.clj:109:48)
        at clojure.lang.Compiler.analyze(Compiler.java:6792)
        at clojure.lang.Compiler.analyze(Compiler.java:6729)
        at clojure.lang.Compiler$InvokeExpr.parse(Compiler.java:3813)
        at clojure.lang.Compiler.analyzeSeq(Compiler.java:7005)
        at clojure.lang.Compiler.analyze(Compiler.java:6773)
        at clojure.lang.Compiler.analyze(Compiler.java:6729)
        at clojure.lang.Compiler$InvokeExpr.parse(Compiler.java:3881)
        at clojure.lang.Compiler.analyzeSeq(Compiler.java:7005)
        at clojure.lang.Compiler.analyze(Compiler.java:6773)
        at clojure.lang.Compiler.analyze(Compiler.java:6729)
        at clojure.lang.Compiler$BodyExpr$Parser.parse(Compiler.java:6100)
        at clojure.lang.Compiler$LetExpr$Parser.parse(Compiler.java:6420)
        at clojure.lang.Compiler.analyzeSeq(Compiler.java:7003)
        at clojure.lang.Compiler.analyze(Compiler.java:6773)
        at clojure.lang.Compiler.analyzeSeq(Compiler.java:6991)
        at clojure.lang.Compiler.analyze(Compiler.java:6773)
        at clojure.lang.Compiler.analyze(Compiler.java:6729)
        at clojure.lang.Compiler$BodyExpr$Parser.parse(Compiler.java:6100)
        at clojure.lang.Compiler$FnMethod.parse(Compiler.java:5460)
        at clojure.lang.Compiler$FnExpr.parse(Compiler.java:4022)
        at clojure.lang.Compiler.analyzeSeq(Compiler.java:7001)
        at clojure.lang.Compiler.analyze(Compiler.java:6773)
        at clojure.lang.Compiler.analyzeSeq(Compiler.java:6991)
        at clojure.lang.Compiler.analyze(Compiler.java:6773)
        at clojure.lang.Compiler.access$300(Compiler.java:38)
        at clojure.lang.Compiler$DefExpr$Parser.parse(Compiler.java:595)
        at clojure.lang.Compiler.analyzeSeq(Compiler.java:7003)
        at clojure.lang.Compiler.analyze(Compiler.java:6773)
        at clojure.lang.Compiler.analyze(Compiler.java:6729)
        at clojure.lang.Compiler.eval(Compiler.java:7066)
        at clojure.lang.Compiler.load(Compiler.java:7514)
        at clojure.lang.RT.loadResourceScript(RT.java:379)
        at clojure.lang.RT.loadResourceScript(RT.java:370)
        at clojure.lang.RT.load(RT.java:460)
        at clojure.lang.RT.load(RT.java:426)
        at clojure.core$load$fn__6548.invoke(core.clj:6046)
        at clojure.core$load.invokeStatic(core.clj:6045)
        at clojure.core$load.doInvoke(core.clj:6029)
        at clojure.lang.RestFn.invoke(RestFn.java:408)
        at clojure.core$load_one.invokeStatic(core.clj:5848)
        at clojure.core$load_one.invoke(core.clj:5843)
        at clojure.core$load_lib$fn__6493.invoke(core.clj:5888)
        at clojure.core$load_lib.invokeStatic(core.clj:5887)
        at clojure.core$load_lib.doInvoke(core.clj:5868)
        at clojure.lang.RestFn.applyTo(RestFn.java:142)
        at clojure.core$apply.invokeStatic(core.clj:659)
        at clojure.core$load_libs.invokeStatic(core.clj:5925)
        at clojure.core$load_libs.doInvoke(core.clj:5909)
        at clojure.lang.RestFn.applyTo(RestFn.java:137)
        at clojure.core$apply.invokeStatic(core.clj:659)
        at clojure.core$require.invokeStatic(core.clj:5947)
        at clojure.core$require.doInvoke(core.clj:5947)
        at clojure.lang.RestFn.invoke(RestFn.java:482)
        at iced.nrepl.namespace$eval20202$loading__6434__auto____20203.invoke(namespace.clj:1)
        at iced.nrepl.namespace$eval20202.invokeStatic(namespace.clj:1)
        at iced.nrepl.namespace$eval20202.invoke(namespace.clj:1)
        at clojure.lang.Compiler.eval(Compiler.java:7062)
        at clojure.lang.Compiler.eval(Compiler.java:7051)
        at clojure.lang.Compiler.load(Compiler.java:7514)
        at clojure.lang.RT.loadResourceScript(RT.java:379)
        at clojure.lang.RT.loadResourceScript(RT.java:370)
        at clojure.lang.RT.load(RT.java:460)
        at clojure.lang.RT.load(RT.java:426)
        at clojure.core$load$fn__6548.invoke(core.clj:6046)
        at clojure.core$load.invokeStatic(core.clj:6045)
        at clojure.core$load.doInvoke(core.clj:6029)
        at clojure.lang.RestFn.invoke(RestFn.java:408)
        at clojure.core$load_one.invokeStatic(core.clj:5848)
        at clojure.core$load_one.invoke(core.clj:5843)
        at clojure.core$load_lib$fn__6493.invoke(core.clj:5888)
        at clojure.core$load_lib.invokeStatic(core.clj:5887)
        at clojure.core$load_lib.doInvoke(core.clj:5868)
        at clojure.lang.RestFn.applyTo(RestFn.java:142)
        at clojure.core$apply.invokeStatic(core.clj:659)
        at clojure.core$load_libs.invokeStatic(core.clj:5925)
        at clojure.core$load_libs.doInvoke(core.clj:5909)
        at clojure.lang.RestFn.applyTo(RestFn.java:137)
        at clojure.core$apply.invokeStatic(core.clj:659)
        at clojure.core$require.invokeStatic(core.clj:5947)
        at clojure.core$require.doInvoke(core.clj:5947)
        at clojure.lang.RestFn.invoke(RestFn.java:457)
        at iced.nrepl.info$eval20196$loading__6434__auto____20197.invoke(info.clj:1)
        at iced.nrepl.info$eval20196.invokeStatic(info.clj:1)
        at iced.nrepl.info$eval20196.invoke(info.clj:1)
        at clojure.lang.Compiler.eval(Compiler.java:7062)
        at clojure.lang.Compiler.eval(Compiler.java:7051)
        at clojure.lang.Compiler.load(Compiler.java:7514)
        at clojure.lang.RT.loadResourceScript(RT.java:379)
        at clojure.lang.RT.loadResourceScript(RT.java:370)
        at clojure.lang.RT.load(RT.java:460)
        at clojure.lang.RT.load(RT.java:426)
        at clojure.core$load$fn__6548.invoke(core.clj:6046)
        at clojure.core$load.invokeStatic(core.clj:6045)
        at clojure.core$load.doInvoke(core.clj:6029)
        at clojure.lang.RestFn.invoke(RestFn.java:408)
        at clojure.core$load_one.invokeStatic(core.clj:5848)
        at clojure.core$load_one.invoke(core.clj:5843)
        at clojure.core$load_lib$fn__6493.invoke(core.clj:5888)
        at clojure.core$load_lib.invokeStatic(core.clj:5887)
        at clojure.core$load_lib.doInvoke(core.clj:5868)
        at clojure.lang.RestFn.applyTo(RestFn.java:142)
        at clojure.core$apply.invokeStatic(core.clj:659)
        at clojure.core$load_libs.invokeStatic(core.clj:5925)
        at clojure.core$load_libs.doInvoke(core.clj:5909)
        at clojure.lang.RestFn.applyTo(RestFn.java:137)
        at clojure.core$apply.invokeStatic(core.clj:659)
        at clojure.core$require.invokeStatic(core.clj:5947)
        at clojure.core$require.doInvoke(core.clj:5947)
        at clojure.lang.RestFn.invoke(RestFn.java:619)
        at iced.nrepl$eval14770$loading__6434__auto____14771.invoke(nrepl.clj:1)
        at iced.nrepl$eval14770.invokeStatic(nrepl.clj:1)
        at iced.nrepl$eval14770.invoke(nrepl.clj:1)
        at clojure.lang.Compiler.eval(Compiler.java:7062)
        at clojure.lang.Compiler.eval(Compiler.java:7051)
        at clojure.lang.Compiler.load(Compiler.java:7514)
        at clojure.lang.RT.loadResourceScript(RT.java:379)
        at clojure.lang.RT.loadResourceScript(RT.java:370)
        at clojure.lang.RT.load(RT.java:460)
        at clojure.lang.RT.load(RT.java:426)
        at clojure.core$load$fn__6548.invoke(core.clj:6046)
        at clojure.core$load.invokeStatic(core.clj:6045)
        at clojure.core$load.doInvoke(core.clj:6029)
        at clojure.lang.RestFn.invoke(RestFn.java:408)
        at clojure.core$load_one.invokeStatic(core.clj:5848)
        at clojure.core$load_one.invoke(core.clj:5843)
        at clojure.core$load_lib$fn__6493.invoke(core.clj:5888)
        at clojure.core$load_lib.invokeStatic(core.clj:5887)
        at clojure.core$load_lib.doInvoke(core.clj:5868)
        at clojure.lang.RestFn.applyTo(RestFn.java:142)
        at clojure.core$apply.invokeStatic(core.clj:659)
        at clojure.core$load_libs.invokeStatic(core.clj:5925)
        at clojure.core$load_libs.doInvoke(core.clj:5909)
        at clojure.lang.RestFn.applyTo(RestFn.java:137)
        at clojure.core$apply.invokeStatic(core.clj:659)
        at clojure.core$require.invokeStatic(core.clj:5947)
        at clojure.core$require.doInvoke(core.clj:5947)
        at clojure.lang.RestFn.invoke(RestFn.java:408)
        at nrepl.cmdline$require_and_resolve.invokeStatic(cmdline.clj:172)
        at nrepl.cmdline$require_and_resolve.invoke(cmdline.clj:163)
        at nrepl.cmdline$fn__1245.invokeStatic(cmdline.clj:177)
        at nrepl.cmdline$fn__1245.invoke(cmdline.clj:177)
        at clojure.core$map$fn__5583$fn__5584.invoke(core.clj:2734)
        at clojure.core$map$fn__5583$fn__5584.invoke(core.clj:2734)
        at clojure.lang.PersistentVector.reduce(PersistentVector.java:341)
        at clojure.core$transduce.invokeStatic(core.clj:6803)
        at clojure.core$into.invokeStatic(core.clj:6819)
        at clojure.core$into.invoke(core.clj:6807)
        at nrepl.cmdline$__GT_mw_list.invokeStatic(cmdline.clj:204)
        at nrepl.cmdline$__GT_mw_list.invoke(cmdline.clj:202)
        at nrepl.cmdline$build_handler.invokeStatic(cmdline.clj:213)
        at nrepl.cmdline$build_handler.invoke(cmdline.clj:206)
        at nrepl.cmdline$run.invokeStatic(cmdline.clj:266)
        at nrepl.cmdline$run.invoke(cmdline.clj:240)
        at nrepl.cmdline$_main.invokeStatic(cmdline.clj:296)
        at nrepl.cmdline$_main.doInvoke(cmdline.clj:293)
        at clojure.lang.RestFn.invoke(RestFn.java:421)
        at iced_repl$_main.invokeStatic(iced_repl.clj:23)
        at iced_repl$_main.invoke(iced_repl.clj:22)
        at clojure.lang.AFn.applyToHelper(AFn.java:152)
        at clojure.lang.AFn.applyTo(AFn.java:144)
        at clojure.lang.Var.applyTo(Var.java:702)
        at clojure.core$apply.invokeStatic(core.clj:657)
        at clojure.main$main_opt.invokeStatic(main.clj:317)
        at clojure.main$main_opt.invoke(main.clj:313)
        at clojure.main$main.invokeStatic(main.clj:424)
        at clojure.main$main.doInvoke(main.clj:387)
        at clojure.lang.RestFn.applyTo(RestFn.java:137)
        at clojure.lang.Var.applyTo(Var.java:702)
        at clojure.main.main(main.java:37)
Caused by: java.lang.RuntimeException: No such var: ns-find/sources-in-jar
        at clojure.lang.Util.runtimeException(Util.java:221)
        at clojure.lang.Compiler.resolveIn(Compiler.java:7273)
        at clojure.lang.Compiler.resolve(Compiler.java:7243)
        at clojure.lang.Compiler.analyzeSymbol(Compiler.java:7204)
        at clojure.lang.Compiler.analyze(Compiler.java:6752)
        ... 168 more
```

A minimal `deps.edn` contains: `{:deps {org.clojure/tools.namespace {:mvn/version "0.2.11"}}}` (see https://github.com/matthias-margush/iced-tools-namespace-conflict). 

This PR fixes the immediate issue. I'm not sure if it's the "right" way to solve it, but it looks like cider-jack-in similarly puts its dependencies on the command line directly.

I'm looking forward to using this plugin - it looks great!