### PR TITLE
Handle one_line_doc responses that are lists.

### DIFF
--- a/autoload/iced/nrepl.vim
+++ b/autoload/iced/nrepl.vim
@@ -98,7 +98,7 @@ function! s:get_message_id(x) abort
   endif
 endfunction
 
-function! s:merge_response_handler(resp, last_result) abort
+function! iced#nrepl#merge_response_handler(resp, last_result) abort
   let result = empty(a:last_result) ? {} : a:last_result
   for resp in iced#util#ensure_array(a:resp)
     for k in keys(resp)
@@ -403,8 +403,8 @@ function! iced#nrepl#interrupt(...) abort
 endfunction
 " }}}
 
-call iced#nrepl#register_handler('eval', funcref('s:merge_response_handler'))
-call iced#nrepl#register_handler('load-file', funcref('s:merge_response_handler'))
+call iced#nrepl#register_handler('eval', funcref('iced#nrepl#merge_response_handler'))
+call iced#nrepl#register_handler('load-file', funcref('iced#nrepl#merge_response_handler'))
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/autoload/iced/nrepl/op/cider.vim
+++ b/autoload/iced/nrepl/op/cider.vim
@@ -178,6 +178,7 @@ function! iced#nrepl#op#cider#pprint_eval(code, callback) abort
       \ })
 endfunction " }}}
 
+call iced#nrepl#register_handler('info', funcref('iced#nrepl#merge_response_handler'))
 call iced#nrepl#register_handler('test-var-query', funcref('s:test_handler'))
 call iced#nrepl#register_handler('retest', funcref('s:test_handler'))
 


### PR DESCRIPTION
`a:resp` in `s:one_line_doc()` appears to be a list, rather than a dict:
```
Error detected while processing function <lambda>8[1]..<SNR>73_dispatcher[47]..<SNR>137_one_line_doc:
line    7:

E715: Dictionary required
```