### PR TITLE
Handle error when quitting and nrepl not running

### DIFF
--- a/autoload/iced/nrepl/sync.vim
+++ b/autoload/iced/nrepl/sync.vim
@@ -44,6 +44,10 @@ endfunction
 
 function! iced#nrepl#sync#session_list() abort
   let resp = iced#nrepl#sync#send({'op': 'ls-sessions'})
+  if empty(resp)
+    return []
+  endif
+
   return get(resp, 'sessions', [])
 endfunction
 


### PR DESCRIPTION
Steps to reproduce:

1. `iced repl`
2. Open a clojure file and `:IcedConnect`
3. Close the iced repl
4. `:quit` editing

```
Timed out.
Error detected while processing function iced#nrepl#auto#leave[2]..iced#nrepl#disconn
ect[3]..iced#nrepl#sync#session_list:
line    2:
E712: Argument of get() must be a List or Dictionary
Error detected while processing function iced#nrepl#auto#leave[2]..iced#nrepl#disconn
ect:
line    3:
E714: List required
```