### PR TITLE
Update docs for shadow-cljs 2.8.20

### DIFF
--- a/doc/vim-iced.txt
+++ b/doc/vim-iced.txt
@@ -154,7 +154,8 @@ SHADOW-CLJS~
                   [cider/cider-nrepl "0.21.1"]
                   [iced-nrepl "0.4.1"]]
 
-   :nrepl {:middleware [cider.nrepl/wrap-classpath
+   :nrepl {:cider false
+           :middleware [cider.nrepl/wrap-classpath
                         cider.nrepl/wrap-complete
                         cider.nrepl/wrap-debug
                         cider.nrepl/wrap-format


### PR DESCRIPTION
This change documents how to remove the automatic cider middleware injection that shadow-cljs does.

See liquidz/vim-iced#82 for why that's an issue.