### PR TITLE
Fix typo in identifier

### DIFF
--- a/autoload/iced/nrepl/op/iced.vim
+++ b/autoload/iced/nrepl/op/iced.vim
@@ -22,7 +22,7 @@ function! iced#nrepl#op#iced#lint_file(file, opt, callback) abort
   let msg = {
       \ 'id': iced#nrepl#id(),
       \ 'op': 'iced-lint-file',
-      \ 'sesion': iced#nrepl#current_session(),
+      \ 'session': iced#nrepl#current_session(),
       \ 'env': iced#nrepl#current_session_key(),
       \ 'file': a:file,
       \ 'callback': a:callback,
@@ -41,7 +41,7 @@ function! iced#nrepl#op#iced#grimoire(platform, ns_name, symbol, callback) abort
 
   call iced#nrepl#send({
         \ 'op': 'iced-grimoire',
-        \ 'sesion': iced#nrepl#current_session(),
+        \ 'session': iced#nrepl#current_session(),
         \ 'platform': a:platform,
         \ 'ns': a:ns_name,
         \ 'symbol': a:symbol,
@@ -55,7 +55,7 @@ function! iced#nrepl#op#iced#spec_check(symbol, num_tests, callback) abort
   call iced#nrepl#send({
         \ 'id': iced#nrepl#id(),
         \ 'op': 'iced-spec-check',
-        \ 'sesion': iced#nrepl#current_session(),
+        \ 'session': iced#nrepl#current_session(),
         \ 'symbol': a:symbol,
         \ 'num-tests': a:num_tests,
         \ 'callback': a:callback,
@@ -68,7 +68,7 @@ function! iced#nrepl#op#iced#project_ns_list(callback) abort
   call iced#nrepl#send({
         \ 'id': iced#nrepl#id(),
         \ 'op': 'iced-project-ns-list',
-        \ 'sesion': iced#nrepl#current_session(),
+        \ 'session': iced#nrepl#current_session(),
         \ 'callback': a:callback,
         \ })
 endfunction " }}}
@@ -79,7 +79,7 @@ function! iced#nrepl#op#iced#find_var_references(ns_name, symbol, callback) abor
   call iced#nrepl#send({
         \ 'id': iced#nrepl#id(),
         \ 'op': 'iced-find-var-references',
-        \ 'sesion': iced#nrepl#current_session(),
+        \ 'session': iced#nrepl#current_session(),
         \ 'ns': a:ns_name,
         \ 'symbol': a:symbol,
         \ 'callback': a:callback,

--- a/autoload/iced/nrepl/op/iced/sync.vim
+++ b/autoload/iced/nrepl/op/iced/sync.vim
@@ -7,7 +7,7 @@ function! iced#nrepl#op#iced#sync#set_indentation_rules(rules, does_overwrite) a
   let msg = {
         \ 'id': iced#nrepl#id(),
         \ 'op': 'iced-set-indentation-rules',
-        \ 'sesion': iced#nrepl#current_session(),
+        \ 'session': iced#nrepl#current_session(),
         \ 'rules': a:rules,
         \ }
 
@@ -24,7 +24,7 @@ function! iced#nrepl#op#iced#sync#format_code(code, alias_map) abort
   return iced#nrepl#sync#send({
         \ 'id': iced#nrepl#id(),
         \ 'op': 'iced-format-code-with-indents',
-        \ 'sesion': iced#nrepl#current_session(),
+        \ 'session': iced#nrepl#current_session(),
         \ 'code': a:code,
         \ 'alias-map': a:alias_map,
         \ })
@@ -36,7 +36,7 @@ function! iced#nrepl#op#iced#sync#calculate_indent_level(code, line_num, alias_m
   return iced#nrepl#sync#send({
         \ 'id': iced#nrepl#id(),
         \ 'op': 'iced-calculate-indent-level',
-        \ 'sesion': iced#nrepl#current_session(),
+        \ 'session': iced#nrepl#current_session(),
         \ 'code': a:code,
         \ 'line-number': a:line_num,
         \ 'alias-map': a:alias_map,
@@ -49,7 +49,7 @@ function! iced#nrepl#op#iced#sync#refactor_thread_first(code) abort
   return iced#nrepl#sync#send({
         \ 'id': iced#nrepl#id(),
         \ 'op': 'iced-refactor-thread-first',
-        \ 'sesion': iced#nrepl#current_session(),
+        \ 'session': iced#nrepl#current_session(),
         \ 'code': a:code,
         \ })
 endfunction
@@ -60,7 +60,7 @@ function! iced#nrepl#op#iced#sync#refactor_thread_last(code) abort
   return iced#nrepl#sync#send({
         \ 'id': iced#nrepl#id(),
         \ 'op': 'iced-refactor-thread-last',
-        \ 'sesion': iced#nrepl#current_session(),
+        \ 'session': iced#nrepl#current_session(),
         \ 'code': a:code,
         \ })
 endfunction

--- a/autoload/iced/nrepl/op/refactor.vim
+++ b/autoload/iced/nrepl/op/refactor.vim
@@ -12,7 +12,7 @@ function! iced#nrepl#op#refactor#clean_ns(callback) abort
       \ 'op': 'clean-ns',
       \ 'path': path,
       \ 'prefix-rewriting': prefix_rewriting,
-      \ 'sesion': iced#nrepl#current_session(),
+      \ 'session': iced#nrepl#current_session(),
       \ 'callback': a:callback,
       \ })
 endfunction
@@ -25,7 +25,7 @@ function! iced#nrepl#op#refactor#add_missing(symbol, callback) abort
   call iced#nrepl#send({
         \ 'op': 'resolve-missing',
         \ 'symbol': symbol,
-        \ 'sesion': iced#nrepl#current_session(),
+        \ 'session': iced#nrepl#current_session(),
         \ 'callback': a:callback,
         \ })
 endfunction
@@ -36,7 +36,7 @@ function! iced#nrepl#op#refactor#find_used_locals(filepath, line, column, callba
   call iced#nrepl#send({
         \ 'op': 'find-used-locals',
         \ 'id': iced#nrepl#id(),
-        \ 'sesion': iced#nrepl#current_session(),
+        \ 'session': iced#nrepl#current_session(),
         \ 'file': a:filepath,
         \ 'line': a:line,
         \ 'column': a:column,


### PR DESCRIPTION
It's a bit of nitpick, but I think `session` is a more suitable name than `sesion`.