### PR TITLE
Support jumping to all Clojure's Symbol

### DIFF
--- a/autoload/iced/nrepl/var.vim
+++ b/autoload/iced/nrepl/var.vim
@@ -4,7 +4,7 @@ set cpoptions&vim
 function! s:cword() abort
   let isk = &iskeyword
   try
-    let &iskeyword = printf('%s,39', isk)
+    let &iskeyword = printf('%s,#,%%,&,39', isk)
     return expand('<cword>')
   finally
     let &iskeyword = isk


### PR DESCRIPTION
This PR supports jumping to all var that is Clojure's Symbol.

In [reference about Symbols](https://clojure.org/reference/reader#_symbols),

>Symbols begin with a non-numeric character and can contain alphanumeric characters and *, +, !, -, _, ', ?, <, > and = (other characters may be allowed eventually).

I think that other characters mean `/`, `#`, `%` and `&`. `/` is already included in [iskeyword in Vim8.1](https://github.com/vim/vim/blob/v8.1.0000/runtime/ftplugin/clojure.vim#L20), so I added others to `iskeyword`.