### PR TITLE
Add options for neovim floating window

### DIFF
--- a/autoload/iced/di/popup/neovim.vim
+++ b/autoload/iced/di/popup/neovim.vim
@@ -22,7 +22,7 @@ function! s:init_win(winid, opts) abort
   call setbufvar(bufnr, '&filetype', get(a:opts, 'filetype', s:default_filetype))
   call setbufvar(bufnr, '&swapfile', 0)
   call setbufvar(bufnr, '&wrap', 0)
-  call setbufvar(bufnr, '&winhl', get(g:, 'iced_nvim_popup_winhl', 'Normal:Folded'))
+  call setbufvar(bufnr, '&winhl', get(g:, 'iced_nvim_popup_winhl', 'Normal:NormalFloat'))
 endfunction
 
 function! s:popup.get_context(winid) abort

--- a/autoload/iced/di/popup/neovim.vim
+++ b/autoload/iced/di/popup/neovim.vim
@@ -145,7 +145,7 @@ function! s:popup.open(texts, ...) abort
   let winid = nvim_open_win(bufnr, v:false, win_opts)
   call s:init_win(winid, opts)
 
-  if has_key(opts, 'filetyoe')
+  if has_key(opts, 'filetype')
     call setbufvar(bufnr, '&filetype', opts['filetype'])
   endif
 

--- a/autoload/iced/di/popup/neovim.vim
+++ b/autoload/iced/di/popup/neovim.vim
@@ -22,7 +22,7 @@ function! s:init_win(winid, opts) abort
   call setbufvar(bufnr, '&filetype', get(a:opts, 'filetype', s:default_filetype))
   call setbufvar(bufnr, '&swapfile', 0)
   call setbufvar(bufnr, '&wrap', 0)
-  call setbufvar(bufnr, '&winhl', 'Normal:Folded')
+  call setbufvar(bufnr, '&winhl', get(g:, 'iced_nvim_popup_winhl', 'Normal:Folded'))
 endfunction
 
 function! s:popup.get_context(winid) abort
@@ -129,6 +129,17 @@ function! s:popup.open(texts, ...) abort
         \ 'width': width,
         \ 'height': height,
         \ }
+
+  if get(g:, 'iced_nvim_popup_minimal_style', v:false)
+    let win_opts = {
+          \ 'relative': 'editor',
+          \ 'row': line,
+          \ 'col': col,
+          \ 'width': width,
+          \ 'height': height,
+          \ 'style': 'minimal',
+          \ }
+  endif
 
   call nvim_buf_set_lines(bufnr, 0, len(texts), 0, texts)
   let winid = nvim_open_win(bufnr, v:false, win_opts)

--- a/autoload/iced/di/popup/neovim.vim
+++ b/autoload/iced/di/popup/neovim.vim
@@ -8,6 +8,9 @@ let s:popup = {
       \ 'env': 'neovim',
       \ }
 
+let g:iced#popup#neovim#winhighlight = get(g:, 'iced#popup#neovim#winhighlight', 'Normal:NormalFloat')
+let g:iced#popup#neovim#style = get(g:, 'iced#popup#neovim#style', 'minimal')
+
 function! s:init_win(winid, opts) abort
   let context = get(a:opts, 'iced_context', {})
   let context['__lnum'] = line('.')
@@ -22,7 +25,7 @@ function! s:init_win(winid, opts) abort
   call setbufvar(bufnr, '&filetype', get(a:opts, 'filetype', s:default_filetype))
   call setbufvar(bufnr, '&swapfile', 0)
   call setbufvar(bufnr, '&wrap', 0)
-  call setbufvar(bufnr, '&winhl', get(g:, 'iced_nvim_popup_winhl', 'Normal:NormalFloat'))
+  call setbufvar(bufnr, '&winhl', g:iced#popup#neovim#winhighlight)
 endfunction
 
 function! s:popup.get_context(winid) abort
@@ -128,18 +131,8 @@ function! s:popup.open(texts, ...) abort
         \ 'col': col,
         \ 'width': width,
         \ 'height': height,
+        \ 'style': g:iced#popup#neovim#style,
         \ }
-
-  if get(g:, 'iced_nvim_popup_minimal_style', v:false)
-    let win_opts = {
-          \ 'relative': 'editor',
-          \ 'row': line,
-          \ 'col': col,
-          \ 'width': width,
-          \ 'height': height,
-          \ 'style': 'minimal',
-          \ }
-  endif
 
   call nvim_buf_set_lines(bufnr, 0, len(texts), 0, texts)
   let winid = nvim_open_win(bufnr, v:false, win_opts)


### PR DESCRIPTION
This adds two global iced options

1. `g:iced_nvim_popup_winhl` to change the popup winhl attribute
2. `g:iced_nvim_minimal_style` to add 'style': 'minimal' to the win_opts.