### PR TITLE
Add option to iced command for overwrite Clojure CLI command

### DIFF
--- a/bin/iced
+++ b/bin/iced
@@ -307,7 +307,14 @@ case "$1" in
                 echo_info "Clojure CLI project is detected"
             fi
 
-            run "clj $OPTIONS -Sdeps '{:deps {iced-repl {:local/root \"${PROJECT_DIR}\"} $(cli_deps_args ${TARGET_DEPENDENCIES}) }}' \
+            CLOJURE_CLI_CMD="clj"
+            if [[ ! -z "${ICED_REPL_CLOJURE_CLI_CMD}" ]]; then
+              CLOJURE_CLI_CMD="${ICED_REPL_CLOJURE_CLI_CMD}"
+              echo_info "Overwrite Clojure CLI command with '${CLOJURE_CLI_CMD}'"
+            fi
+
+            run "$CLOJURE_CLI_CMD \
+                         $OPTIONS -Sdeps '{:deps {iced-repl {:local/root \"${PROJECT_DIR}\"} $(cli_deps_args ${TARGET_DEPENDENCIES}) }}' \
                          -m nrepl.cmdline $(cli_middleware_args ${TARGET_MIDDLEWARES}) --interactive"
         elif [ $IS_SHADOW_CLJS -eq 1 ]; then
             echo_error 'Currently iced command does not support shadow-cljs.'

--- a/clj/template/iced.bash
+++ b/clj/template/iced.bash
@@ -307,7 +307,14 @@ case "$1" in
                 echo_info "Clojure CLI project is detected"
             fi
 
-            run "clj $OPTIONS -Sdeps '{:deps {iced-repl {:local/root \"${PROJECT_DIR}\"} $(cli_deps_args ${TARGET_DEPENDENCIES}) }}' \
+            CLOJURE_CLI_CMD="clj"
+            if [[ ! -z "${ICED_REPL_CLOJURE_CLI_CMD}" ]]; then
+              CLOJURE_CLI_CMD="${ICED_REPL_CLOJURE_CLI_CMD}"
+              echo_info "Overwrite Clojure CLI command with '${CLOJURE_CLI_CMD}'"
+            fi
+
+            run "$CLOJURE_CLI_CMD \
+                         $OPTIONS -Sdeps '{:deps {iced-repl {:local/root \"${PROJECT_DIR}\"} $(cli_deps_args ${TARGET_DEPENDENCIES}) }}' \
                          -m nrepl.cmdline $(cli_middleware_args ${TARGET_MIDDLEWARES}) --interactive"
         elif [ $IS_SHADOW_CLJS -eq 1 ]; then
             echo_error 'Currently iced command does not support shadow-cljs.'


### PR DESCRIPTION
The `iced` command seems to supports not only Clojure CLI but also Leinningen or boot. 
So, adding this kind of option for `iced repl` is not suitable, maybe 🤔. 

How about specifing from env var?

Feel free to close this PR.
This is only a suggestion.
