### PR TITLE
Preserve alternative window during s:scroll_to_bottom

### DIFF
--- a/autoload/iced/buffer.vim
+++ b/autoload/iced/buffer.vim
@@ -111,6 +111,7 @@ function! s:scroll_to_bottom(nr, _) abort
     call s:focus_window(bufwinnr(a:nr))
     silent normal! G
   finally
+    " Preserve the user's last visited window by focusing to it first (PR #187)
     call s:focus_window(last_window)
     call s:focus_window(current_window)
     let &eventignore = ''

--- a/autoload/iced/buffer.vim
+++ b/autoload/iced/buffer.vim
@@ -105,11 +105,13 @@ endfunction
 
 function! s:scroll_to_bottom(nr, _) abort
   let current_window = winnr()
+  let last_window = winnr('#')
   try
     let &eventignore = 'WinEnter,BufEnter'
     call s:focus_window(bufwinnr(a:nr))
     silent normal! G
   finally
+    call s:focus_window(last_window)
     call s:focus_window(current_window)
     let &eventignore = ''
   endtry


### PR DESCRIPTION
When vim-iced's output window is open, pressing <kbd>\<C-W\>p</kbd> (alternative window) after `s:scroll_to_bottom` is called in the background brings the user to vim-iced's output window instead of the user's previous alternative window. This PR fixes that problem.

If other changes are needed, please let me know. Also feel free to accept or reject this PR. :)