### PR TITLE
Updated script to use /usr/bin/env

### DIFF
--- a/bin/iced
+++ b/bin/iced
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CWD=$(pwd)
 SCRIPT_DIR=$(cd $(dirname $0); pwd)

--- a/clj/template/iced.bash
+++ b/clj/template/iced.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CWD=$(pwd)
 SCRIPT_DIR=$(cd $(dirname $0); pwd)


### PR DESCRIPTION
The script uses `/bin/bash` which isn't compatible with [NixOS][issue]. This updates it to use `/usr/bin/env bash` instead

[issue]: https://github.com/NixOS/nixpkgs/issues/25322