### PR TITLE
Add documentation to embed an nREPL, specifically for Rebel Readline

### DIFF
--- a/doc/vim-iced.txt
+++ b/doc/vim-iced.txt
@@ -245,8 +245,7 @@ REBEL READLINE~
   (defn start-nrepl-server! []
     (reset!
       nrepl-server
-        (nrepl-server/start-server :port nrepl-port :handler (nrepl-handler))
-    )
+        (nrepl-server/start-server :port nrepl-port :handler (nrepl-handler)))
     (println "Cider nREPL server started on port" nrepl-port)
     (spit ".nrepl-port" nrepl-port))
 

--- a/doc/vim-iced.txt
+++ b/doc/vim-iced.txt
@@ -224,8 +224,9 @@ REBEL READLINE~
   If you use Rebel Readline or want to embed an nREPL in your application,
   then one approach is to create a `user.clj` with the following:
 >
-  (ns user (:require [nrepl.server :as nrepl-server]
-                  [clojure.java.io :as io]))
+  (ns user
+    (:require [nrepl.server :as nrepl-server]
+              [clojure.java.io :as io]))
   
   (def nrepl-port 7888)
   (defonce nrepl-server (atom nil))

--- a/doc/vim-iced.txt
+++ b/doc/vim-iced.txt
@@ -14,6 +14,7 @@ CONTENTS                                                    *vim-iced-contents*
       Leiningen                |vim-iced-manual-leiningen|
       Boot                     |vim-iced-manual-boot|
       shadow-cljs              |vim-iced-manual-shadow-cljs|
+      Rebel Readline           |vim-iced-manual-rebel-readline|
     Boost by Python            |vim-iced-install-python|
     Docker                     |vim-iced-install-docker|
   REPL Connection              |vim-iced-repl-connection|
@@ -216,6 +217,48 @@ SHADOW-CLJS~
                 iced.nrepl/wrap-iced]}
 <
   To start CLJS REPL, see |vim-iced-shadow-cljs|.
+
+                                              *vim-iced-manual-rebel-readline*
+REBEL READLINE~
+
+  If you use Rebel Readline or want to embed an nREPL in your application,
+  then one approach is to create a `user.clj` with the following:
+>  
+  (ns user (:require [nrepl.server :as nrepl-server]
+                  [clojure.java.io :as io]))
+  
+  (def nrepl-port 7888)
+  (defonce nrepl-server (atom nil))
+
+  (defn cider-middleware
+    "Get cider middleware, see 
+    https://github.com/clojure-emacs/cider-nrepl/issues/447"
+    []
+    (require 'cider.nrepl)
+    (map resolve (var-get (ns-resolve 'cider.nrepl 'cider-middleware))))
+
+  (defn dev-middleware []
+    (mapcat (fn [[ns syms]] (require ns) (map (partial ns-resolve ns) syms))
+    [['refactor-nrepl.middleware ['wrap-refactor]] ['iced.nrepl ['wrap-iced]]]))
+   
+  (defn start-nrepl-server! []
+    (reset!
+      nrepl-server
+        (nrepl-server/start-server :port nrepl-port :handler (nrepl-handler))
+    )
+    (println "Cider nREPL server started on port" nrepl-port)
+    (spit ".nrepl-port" nrepl-port))
+
+  (defn stop-nrepl-server! []
+    (when (not (nil? @nrepl-server))
+      (nrepl-server/stop-server @nrepl-server)
+      (println "Cider nREPL server on port" nrepl-port "stopped")
+      (reset! nrepl-server nil)
+      (io/delete-file ".nrepl-port" true)
+      (System/exit 0)))
+<  
+  Start the Rebel Readline REPL and from it's prompt start the nREPL server 
+  using `start-nrepl-server!`, then in Vim do `:IcedConnect`.
 
 ==============================================================================
 BOOST BY PYTHON                                       *vim-iced-install-python*

--- a/doc/vim-iced.txt
+++ b/doc/vim-iced.txt
@@ -241,6 +241,11 @@ REBEL READLINE~
   (defn dev-middleware []
     (mapcat (fn [[ns syms]] (require ns) (map (partial ns-resolve ns) syms))
     [['refactor-nrepl.middleware ['wrap-refactor]] ['iced.nrepl ['wrap-iced]]]))
+    
+  (defn nrepl-handler
+    "Re-implement cider-nrepl-handler so we can add middleware to the default list"
+    []
+    (apply nrepl-server/default-handler (concat (cider-middleware) (dev-middleware))))
    
   (defn start-nrepl-server! []
     (reset!

--- a/doc/vim-iced.txt
+++ b/doc/vim-iced.txt
@@ -223,7 +223,7 @@ REBEL READLINE~
 
   If you use Rebel Readline or want to embed an nREPL in your application,
   then one approach is to create a `user.clj` with the following:
->  
+>
   (ns user (:require [nrepl.server :as nrepl-server]
                   [clojure.java.io :as io]))
   

--- a/doc/vim-iced.txt
+++ b/doc/vim-iced.txt
@@ -236,7 +236,9 @@ REBEL READLINE~
     https://github.com/clojure-emacs/cider-nrepl/issues/447"
     []
     (require 'cider.nrepl)
-    (map resolve (var-get (ns-resolve 'cider.nrepl 'cider-middleware))))
+    (map ns-resolve 
+       ['cider.nrepl 'cider.nrepl 'cider.nrepl 'cider.nrepl 'cider.nrepl 'cider.nrepl 'cider.nrepl 'cider.nrepl 'cider.nrepl 'cider.nrepl 'cider.nrepl 'cider.nrepl 'cider.nrepl 'cider.nrepl] 
+       ['wrap-classpath 'wrap-clojuredocs 'wrap-complete 'wrap-debug 'wrap-format 'wrap-info 'wrap-macroexpand 'wrap-ns 'wrap-out 'wrap-spec 'wrap-test 'wrap-trace 'wrap-undef 'wrap-xref]))
 
   (defn dev-middleware []
     (mapcat (fn [[ns syms]] (require ns) (map (partial ns-resolve ns) syms))

--- a/doc/vim-iced.txt
+++ b/doc/vim-iced.txt
@@ -257,7 +257,7 @@ REBEL READLINE~
       (reset! nrepl-server nil)
       (io/delete-file ".nrepl-port" true)
       (System/exit 0)))
-<  
+<
   Start the Rebel Readline REPL and from it's prompt start the nREPL server 
   using `start-nrepl-server!`, then in Vim do `:IcedConnect`.
 


### PR DESCRIPTION
Rebel Readline (https://github.com/bhauman/rebel-readline) is a user-friendly REPL that goes well with vim-iced. It only has a local service, so you have to create an nREPL after it's been started. This means you have to embed an nREPL. 

 It would be nicer to create an nREPL service in Rebel Readline, but it's too complicated!

Added documentation and example 'user.clj'.

@agriffis came up with this solution at https://github.com/clojure-emacs/cider-nrepl/issues/447#issuecomment-570826543