### PR TITLE
Add . and / to cword iskeyword

### DIFF
--- a/autoload/iced/nrepl/var.vim
+++ b/autoload/iced/nrepl/var.vim
@@ -4,7 +4,7 @@ set cpoptions&vim
 function! iced#nrepl#var#cword() abort
   let isk = &iskeyword
   try
-    setlocal iskeyword=@,48-57,_,192-255,?,-,*,!,+,/,=,<,>,.,:,$,#,%,&,'
+    let &iskeyword = '@,48-57,_,192-255,?,-,*,!,+,/,=,<,>,.,:,$,#,%,&,39'
     return expand('<cword>')
   finally
     let &iskeyword = isk

--- a/autoload/iced/nrepl/var.vim
+++ b/autoload/iced/nrepl/var.vim
@@ -4,7 +4,7 @@ set cpoptions&vim
 function! iced#nrepl#var#cword() abort
   let isk = &iskeyword
   try
-    let &iskeyword = printf('%s,#,%%,&,39,.,/', isk)
+    setlocal iskeyword=@,48-57,_,192-255,?,-,*,!,+,/,=,<,>,.,:,$,#,%,&,'
     return expand('<cword>')
   finally
     let &iskeyword = isk

--- a/autoload/iced/nrepl/var.vim
+++ b/autoload/iced/nrepl/var.vim
@@ -4,7 +4,7 @@ set cpoptions&vim
 function! iced#nrepl#var#cword() abort
   let isk = &iskeyword
   try
-    let &iskeyword = printf('%s,#,%%,&,39', isk)
+    let &iskeyword = printf('%s,#,%%,&,39,.,/', isk)
     return expand('<cword>')
   finally
     let &iskeyword = isk


### PR DESCRIPTION
I usually remove `.` from `iskeyword` to make word-wise movement easier,
however this can break functions like `jump_to_def` because incomplete symbol.

How about adding those characters to `iskeyword` as an safety guard? Avoid affected by user setting.
