### PR TITLE
Proposal to allow doing jump-to-def with new tab

### DIFF
--- a/autoload/iced/nrepl/navigate.vim
+++ b/autoload/iced/nrepl/navigate.vim
@@ -135,14 +135,18 @@ function! iced#nrepl#navigate#related_ns() abort
 endfunction " }}}
 
 " iced#nrepl#navigate#jump_to_def {{{
-function! iced#nrepl#navigate#jump_to_def(symbol, ...) abort
+" arguments signatures:
+"   []                 -> use cword as symbol
+"   [symbol]           -> use 'edit' as jump_cmd
+"   [symbol, jump_cmd]
+"   ['.', jump_cmd]    -> '.' is a dummy symbol, use cword
+function! iced#nrepl#navigate#jump_to_def(...) abort
   call iced#system#get('tagstack').add_here()
 
-  let symbol = empty(a:symbol)
+  let jump_cmd = a:0 > 1 ? a:2 : 'edit'
+  let symbol = (a:0 == 0 || a:1 == '.')
         \ ? iced#nrepl#var#cword()
-        \ : a:symbol
-
-  let jump_cmd = a:0 > 0 ? a:1 : 'edit'
+        \ : a:1
 
   let kondo = iced#system#get('clj_kondo')
   if stridx(symbol, '::') == 0

--- a/autoload/iced/nrepl/navigate.vim
+++ b/autoload/iced/nrepl/navigate.vim
@@ -262,7 +262,7 @@ function! s:jump(base_symbol, jump_cmd, resp) abort
   endif
 
   if expand('%:p') !=# path
-    call iced#system#get('ex_cmd').exe(printf('%s %s', a:jump_cmd, path))
+    call iced#system#get('ex_cmd').exe(printf(':%s %s', a:jump_cmd, path))
   endif
 
   call cursor(line, column)

--- a/autoload/iced/nrepl/navigate.vim
+++ b/autoload/iced/nrepl/navigate.vim
@@ -135,12 +135,14 @@ function! iced#nrepl#navigate#related_ns() abort
 endfunction " }}}
 
 " iced#nrepl#navigate#jump_to_def {{{
-function! iced#nrepl#navigate#jump_to_def(symbol) abort
+function! iced#nrepl#navigate#jump_to_def(symbol, ...) abort
   call iced#system#get('tagstack').add_here()
 
   let symbol = empty(a:symbol)
         \ ? iced#nrepl#var#cword()
         \ : a:symbol
+
+  let jump_cmd = a:0 > 0 ? a:1 : 'edit'
 
   let kondo = iced#system#get('clj_kondo')
   if stridx(symbol, '::') == 0
@@ -150,10 +152,10 @@ function! iced#nrepl#navigate#jump_to_def(symbol) abort
     if ! empty(local_def)
       return s:jump_to_local_definition(local_def)
     else
-      return iced#nrepl#var#get(symbol, funcref('s:jump', [symbol]))
+      return iced#nrepl#var#get(symbol, funcref('s:jump', [symbol, jump_cmd]))
     endif
   else
-    return iced#nrepl#var#get(symbol, funcref('s:jump', [symbol]))
+    return iced#nrepl#var#get(symbol, funcref('s:jump', [symbol, jump_cmd]))
   endif
 endfunction
 
@@ -220,7 +222,7 @@ function!  s:jump_to_local_definition(local_def) abort
   call cursor(row, col)
 endfunction
 
-function! s:jump(base_symbol, resp) abort
+function! s:jump(base_symbol, jump_cmd, resp) abort
   let path = ''
   let line = 0
   let column = 0
@@ -256,7 +258,7 @@ function! s:jump(base_symbol, resp) abort
   endif
 
   if expand('%:p') !=# path
-    call iced#system#get('ex_cmd').exe(printf(':edit %s', path))
+    call iced#system#get('ex_cmd').exe(printf('%s %s', a:jump_cmd, path))
   endif
 
   call cursor(line, column)

--- a/doc/pages/navigation.adoc
+++ b/doc/pages/navigation.adoc
@@ -4,7 +4,7 @@
 
 vim-iced provides {help_html}#%3AIcedDefJump[IcedDefJump] command for jumping to definition.
 
-It is also supported to jump to qualified keywords and local vars.
+It supports jumping to qualified keywords and local vars, can also specify using split window, tab, or other ways to open target location.
 
 If you jumped to a definition with above command, vim-iced add the current cursor position to Vim's https://vim-jp.org/vimdoc-en/tagsrch.html#tagstack[tag stack].
 So you can go back easily with https://vim-jp.org/vimdoc-en/tagsrch.html#CTRL-T[<C-t>].

--- a/doc/vim-iced.txt
+++ b/doc/vim-iced.txt
@@ -918,8 +918,14 @@ COMMANDS                                                    *vim-iced-commands*
   Key is mapped to |<Plug>(iced_stdout_buffer_toggle)|.
 
                                                                  *:IcedDefJump*
-:IcedDefJump
-  Jump cursor to definition of symbol under cursor.
+:IcedDefJump [{symbol}, {jump-cmd}]
+  Jump cursor to definition of {symbol} (default to symbol under cursor).
+
+  {jump-cmd} is used to specify how to open the new buffer, default to |edit|.
+
+  To specify {jump-cmd} while still use symbol under cursor automatically,
+  pass '.' as first argument.
+
   Key is mapped to |<Plug>(iced_def_jump)|.
 
                                                                   *:IcedOpenNs*

--- a/doc/vim-iced.txt
+++ b/doc/vim-iced.txt
@@ -925,7 +925,9 @@ COMMANDS                                                    *vim-iced-commands*
 
   To specify {jump-cmd} while still use symbol under cursor automatically,
   pass '.' as first argument.
-
+  E.g. >
+  :nmap <buffer> g<C-]> :<C-u>IcedDefJump . tabedit<CR>
+<
   Key is mapped to |<Plug>(iced_def_jump)|.
 
                                                                   *:IcedOpenNs*

--- a/ftplugin/clojure.vim
+++ b/ftplugin/clojure.vim
@@ -113,7 +113,7 @@ command!          IcedStdoutBufferClear     call iced#buffer#stdout#clear()
 command!          IcedStdoutBufferClose     call iced#buffer#stdout#close()
 command!          IcedStdoutBufferToggle    call iced#buffer#stdout#toggle()
 
-command! -nargs=? IcedDefJump               call iced#nrepl#navigate#jump_to_def(<q-args>)
+command! -nargs=* IcedDefJump               call iced#nrepl#navigate#jump_to_def(<f-args>)
 command! -nargs=1 -complete=custom,iced#nrepl#navigate#ns_complete
       \ IcedOpenNs                          call iced#nrepl#navigate#open_ns('e', <q-args>)
 


### PR DESCRIPTION
Hi, this is an preliminary PR, hope to request a feature.

I personally use tabpages more than buffers, and hope we can do `IcedDefJump` alike but open new location with new tab, similar to Vim's `gf` and `CTRL-W gf` variant.

Would you accept such functionality? I think it would be useful, for example, user want to keep their current location but open the jump target other way (e.g., `split` window).
