### PR TITLE
Support Windows using MSYS2

### DIFF
--- a/bin/iced.cmd
+++ b/bin/iced.cmd
@@ -1,0 +1,4 @@
+@echo off
+set dp0=%~dp0
+
+bash "%dp0%/iced" %*


### PR DESCRIPTION
I confirmed the example introduced in [the document](https://liquidz.github.io/vim-iced/#quick_start) works on Windows. But I had to install more dependencies:

- MSYS2 (Or any other similar systems such as Cygwin would work).
- The `lein` script in shell script: <https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein>.
    - `lein.bat` can't be called by the `iced` shell script.