### PR TITLE
Bump versions of zprint, jet, joker in installers

### DIFF
--- a/installer/jet.sh
+++ b/installer/jet.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-version='0.0.15'
+version='0.1.0'
 file='jet.zip'
 if [ "$(uname)" == 'Darwin' ]; then
     os='macos'

--- a/installer/joker.sh
+++ b/installer/joker.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-version='0.17.2'
+version='0.17.3'
 file='joker.zip'
 if [ "$(uname)" == 'Darwin' ]; then
     os='mac'

--- a/installer/zprint-clj.sh
+++ b/installer/zprint-clj.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-version='1.2.01'
+version='1.2.0'
 # NOTE: macOS has a same named command, so add '-clj' postfix
 file='zprint-clj'
 if [ "$(uname)" == 'Darwin' ]; then


### PR DESCRIPTION
There's no version `1.2.01` on zprint's [releases](https://github.com/kkinnear/zprint/releases) page.