### PR TITLE
Improve evaluation experience for large values

### DIFF
--- a/autoload/iced/nrepl.vim
+++ b/autoload/iced/nrepl.vim
@@ -249,7 +249,7 @@ function! s:dispatcher(ch, resp) abort
   "" To avoid freezing vim/nvim when too large values are returned.
   "" c.f. https://github.com/liquidz/vim-iced/issues/219
   if text_len > g:iced#nrepl#buffer_size
-    call iced#message#error('too_large_values')
+    call iced#message#warning('too_large_values')
     if g:iced#nrepl#skip_evaluation_when_buffer_size_is_exceeded
       let s:response_buffer = ''
       let s:messages = {}

--- a/message/iced/en.txt
+++ b/message/iced/en.txt
@@ -103,7 +103,7 @@
   'timeout':                   'Timed out.',
   'toggle_warn_on_reflection': 'Toggled *warn-on-reflection* to %s.',
   'too_deep_to_slurp':         'Too deep to slurp.',
-  'too_large_values':          'Timed out because evaluated values are too large.',
+  'too_large_values':          'Evaluating values too large may freeze vim. See: g:iced#nrepl#skip_evaluation_when_buffer_size_is_exceeded',
   'try_connect':               'Not connected. Try `:IcedConnect <port>`',
   'unaliased':                 'Unaliased "%s".',
   'undefined':                 'Undefined %s.',
@@ -117,4 +117,4 @@
 
   '___EOF___': ''
 }
-#vim:ft=ruby
+# vim:ft=ruby

--- a/python/bencode.py
+++ b/python/bencode.py
@@ -4,7 +4,7 @@ def __decode_string(b, start=0):
     """
     >>> __decode_string(b'3:foo3:bar')
     {'value': 'foo', 'start': 5}
-    >> __decode_string(b'3:foo3:bar', start=5)
+    >>> __decode_string(b'3:foo3:bar', start=5)
     {'value': 'bar', 'start': 10}
     >>> __decode_string(b'0:3:bar')
     {'value': '', 'start': 2}

--- a/python/bencode.py
+++ b/python/bencode.py
@@ -4,6 +4,8 @@ def __decode_string(b, start=0):
     """
     >>> __decode_string(b'3:foo3:bar')
     {'value': 'foo', 'start': 5}
+    >> __decode_string(b'3:foo3:bar', start=5)
+    {'value': 'bar', 'start': 10}
     >>> __decode_string(b'0:3:bar')
     {'value': '', 'start': 2}
     """
@@ -17,6 +19,8 @@ def __decode_integer(b, start=0):
     """
     >>> __decode_integer(b'i123e3:foo')
     {'value': 123, 'start': 5}
+    >>> __decode_integer(b'i123ei4567e', start=5)
+    {'value': 4567, 'start': 11}
     """
     epos = b.find(b'e', start)
     if epos == -1:
@@ -27,8 +31,10 @@ def __decode_list(b, start=0):
     """
     >>> __decode_list(b'li123e3:foo0:e3:bar')
     {'value': [123, 'foo', ''], 'start': 14}
-    >>> __decode_list(b'le3:bar')
+    >>> __decode_list(b'lel3:bare')
     {'value': [], 'start': 2}
+    >>> __decode_list(b'lel3:bare', start=2)
+    {'value': ['bar'], 'start': 9}
     >>> __decode_list(b'llee3:bar')
     {'value': [[]], 'start': 4}
     """
@@ -46,6 +52,8 @@ def __decode_dict(b, start=0):
     {'value': {'foo': 123}, 'start': 12}
     >>> __decode_dict(b'de3:bar')
     {'value': {}, 'start': 2}
+    >>> __decode_dict(b'ded3:bari1ee', start=2)
+    {'value': {'bar': 1}, 'start': 12}
     """
     start += 1
     result = {}
@@ -88,11 +96,11 @@ def iced_bencode_decode(s):
     '__FAILED__'
     """
     result = []
-    s = s.encode('utf-8')
+    b = s.encode('utf-8')
     start = 0
     try:
-        while start < len(s):
-            ret = __decode(s, start)
+        while start < len(b):
+            ret = __decode(b, start)
             result.append(ret['value'])
             start = ret['start']
         if len(result) == 1:

--- a/python/bencode.py
+++ b/python/bencode.py
@@ -1,76 +1,72 @@
 #!/usr/bin/python3
 
-def __decode_string(s):
+def __decode_string(b, start=0):
     """
-    >>> __decode_string('3:foo3:bar')
-    {'value': 'foo', 'rest': '3:bar'}
-    >>> __decode_string('0:3:bar')
-    {'value': '', 'rest': '3:bar'}
+    >>> __decode_string(b'3:foo3:bar')
+    {'value': 'foo', 'start': 5}
+    >>> __decode_string(b'0:3:bar')
+    {'value': '', 'start': 2}
     """
-    i = s.find(':')
-    if i == -1:
-        raise Exception('failed to decode string token', s)
-    else:
-        l = int(s[:i])
-        b = s[i+1:].encode()
-        return {'value': b[:l].decode(encoding='utf-8'), 'rest': b[l:].decode(encoding='utf-8')}
+    cpos = b.find(b':', start)
+    if cpos == -1:
+        raise Exception('failed to decode string token', b[start:])
+    l = int(b[start:cpos])
+    return {'value': b[cpos+1:cpos+1+l].decode(encoding='utf-8'), 'start': cpos+1+l}
 
-def __decode_integer(s):
+def __decode_integer(b, start=0):
     """
-    >>> __decode_integer('i123e3:foo')
-    {'value': 123, 'rest': '3:foo'}
+    >>> __decode_integer(b'i123e3:foo')
+    {'value': 123, 'start': 5}
     """
-    i = s.find('e')
-    if i == -1:
+    epos = b.find(b'e', start)
+    if epos == -1:
         raise Exception('failed to decode integer token')
-    else:
-        return {'value': int(s[1:i]), 'rest': s[i+1:]}
+    return {'value': int(b[start+1:epos]), 'start': epos+1}
 
-def __decode_list(s):
+def __decode_list(b, start=0):
     """
-    >>> __decode_list('li123e3:foo0:e3:bar')
-    {'value': [123, 'foo', ''], 'rest': '3:bar'}
-    >>> __decode_list('le3:bar')
-    {'value': [], 'rest': '3:bar'}
-    >>> __decode_list('llee3:bar')
-    {'value': [[]], 'rest': '3:bar'}
+    >>> __decode_list(b'li123e3:foo0:e3:bar')
+    {'value': [123, 'foo', ''], 'start': 14}
+    >>> __decode_list(b'le3:bar')
+    {'value': [], 'start': 2}
+    >>> __decode_list(b'llee3:bar')
+    {'value': [[]], 'start': 4}
     """
-    rest = s[1:]
+    start += 1
     result = []
-    while rest[0] != 'e':
-        decoded = __decode(rest)
+    while chr(b[start]) != 'e':
+        decoded = __decode(b, start)
         result.append(decoded['value'])
-        rest = decoded['rest']
-    return {'value': result, 'rest': rest[1:]}
+        start = decoded['start']
+    return {'value': result, 'start': start+1}
 
-def __decode_dict(s):
+def __decode_dict(b, start=0):
     """
-    >>> __decode_dict('d3:fooi123ee3:bar')
-    {'value': {'foo': 123}, 'rest': '3:bar'}
-    >>> __decode_dict('de3:bar')
-    {'value': {}, 'rest': '3:bar'}
+    >>> __decode_dict(b'd3:fooi123ee3:bar')
+    {'value': {'foo': 123}, 'start': 12}
+    >>> __decode_dict(b'de3:bar')
+    {'value': {}, 'start': 2}
     """
-    rest = s[1:]
+    start += 1
     result = {}
-    while rest[0] != 'e':
-        k = __decode(rest)
-        v = __decode(k['rest'])
+    while chr(b[start]) != 'e':
+        k = __decode(b, start)
+        v = __decode(b, k['start'])
         result[k['value']] = v['value']
-        rest = v['rest']
-    return {'value': result, 'rest': rest[1:]}
+        start = v['start']
+    return {'value': result, 'start': start+1}
 
-def __decode(s):
-    c = s[0]
+def __decode(b, start=0):
+    c = chr(b[start])
     if c in {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}:
-        return __decode_string(s)
+        return __decode_string(b, start)
     elif c == 'i':
-        return __decode_integer(s)
+        return __decode_integer(b, start)
     elif c == 'l':
-        return __decode_list(s)
+        return __decode_list(b, start)
     elif c == 'd':
-        return __decode_dict(s)
-    else:
-        raise Exception('invalid token')
+        return __decode_dict(b, start)
+    raise Exception('invalid token ' + c)
 
 def iced_bencode_decode(s):
     """
@@ -92,16 +88,16 @@ def iced_bencode_decode(s):
     '__FAILED__'
     """
     result = []
-    rest = s
+    s = s.encode('utf-8')
+    start = 0
     try:
-        while rest != '':
-            ret = __decode(rest)
+        while start < len(s):
+            ret = __decode(s, start)
             result.append(ret['value'])
-            rest = ret['rest']
+            start = ret['start']
         if len(result) == 1:
             return result[0]
-        else:
-            return result
+        return result
     except Exception:
         return '__FAILED__'
 
@@ -135,5 +131,4 @@ def iced_vim_repr(x):
     elif t is dict:
         ret = [iced_vim_repr(k) + ':' + iced_vim_repr(v) for k,v in x.items()]
         return '{' + ','.join(ret) + '}'
-    else:
-        raise Exception
+    raise Exception


### PR DESCRIPTION
The other day I had a cider-nrepl server started inside a project that doesn't have iced-nrepl in it. When I `:IcedConnect` to it, it sent back a 1,201,722-byte bencoded string (I'm not familiar with the nrepl protocol so have no idea what it is; it began with a `d18:changed-namespaces` dict) which froze my nvim for 79 seconds... that's a throughput of 15KB/s and sounds a bit too slow. Profiling shows:

<details>

```
FUNCTIONS SORTED ON SELF TIME
count  total (s)   self (s)  function
   10  78.780231  78.630764  provider#python3#Call()
    8             78.627463  <SNR>292_decode_via_python()
```

```
    327019 function calls (255933 primitive calls) in 70.975 seconds

    Ordered by: standard name
 
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
         1    0.000    0.000    0.000    0.000 _bootlocale.py:33(getpreferredencoding)
         1    0.000    0.000    0.000    0.000 bencode.py:18(__decode_integer)
         1    0.000    0.000    0.000    0.000 bencode.py:29(__decode_list)
         1    0.004    0.004   70.975   70.975 bencode.py:3(<module>)
     51182   13.666    0.000   61.401    0.001 bencode.py:3(__decode_string)
    9952/1    7.920    0.001   70.969   70.969 bencode.py:46(__decode_dict)
   61136/1    1.647    0.000   70.969   70.969 bencode.py:62(__decode)
         1    0.000    0.000   70.969   70.969 bencode.py:75(iced_bencode_decode)
         1    0.000    0.000    0.000    0.000 codecs.py:260(__init__)
         1    0.000    0.000    0.000    0.000 codecs.py:309(__init__)
         1    0.000    0.000    0.002    0.002 codecs.py:319(decode)
         1    0.002    0.002    0.002    0.002 {built-in method _codecs.utf_8_decode}
         1    0.000    0.000    0.000    0.000 {built-in method _locale.nl_langinfo}
         1    0.000    0.000   70.975   70.975 {built-in method builtins.exec}
         2    0.000    0.000    0.000    0.000 {built-in method builtins.len}
         1    0.000    0.000    0.000    0.000 {built-in method builtins.print}
         1    0.000    0.000    0.000    0.000 {built-in method io.open}
         1    0.000    0.000    0.000    0.000 {method '__exit__' of '_io._IOBase' objects}
         2    0.000    0.000    0.000    0.000 {method 'append' of 'list' objects}
    102364   14.094    0.000   14.094    0.000 {method 'decode' of 'bytes' objects}
         1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
     51182   33.599    0.001   33.599    0.001 {method 'encode' of 'str' objects}
     51183    0.043    0.000    0.043    0.000 {method 'find' of 'str' objects}
         1    0.001    0.001    0.003    0.003 {method 'read' of '_io.TextIOWrapper' objects}
```

</details>

So this PR improves that by

* Reducing the excessive number of calls to `.encode()` and `.decode()`.
* Avoiding creating new strings by slicing on every return.

Profiling after the changes:

<details>

```
FUNCTIONS SORTED ON SELF TIME
count  total (s)   self (s)  function
   10   3.374407   3.205914  provider#python3#Call()
    8              3.203132  <SNR>292_decode_via_python()
```

```
         326315 function calls (255229 primitive calls) in 0.140 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    0.000    0.000 _bootlocale.py:33(getpreferredencoding)
        1    0.000    0.000    0.000    0.000 bencode.py:16(__decode_integer)
        1    0.000    0.000    0.000    0.000 bencode.py:26(__decode_list)
        1    0.001    0.001    0.140    0.140 bencode.py:3(<module>)
    51182    0.049    0.000    0.073    0.000 bencode.py:3(__decode_string)
   9952/1    0.027    0.000    0.135    0.135 bencode.py:43(__decode_dict)
  61136/1    0.028    0.000    0.135    0.135 bencode.py:59(__decode)
        1    0.000    0.000    0.136    0.136 bencode.py:71(iced_bencode_decode)
        1    0.000    0.000    0.000    0.000 codecs.py:260(__init__)
        1    0.000    0.000    0.000    0.000 codecs.py:309(__init__)
        1    0.000    0.000    0.001    0.001 codecs.py:319(decode)
        1    0.001    0.001    0.001    0.001 {built-in method _codecs.utf_8_decode}
        1    0.000    0.000    0.000    0.000 {built-in method _locale.nl_langinfo}
   101657    0.008    0.000    0.008    0.000 {built-in method builtins.chr}
        1    0.000    0.000    0.140    0.140 {built-in method builtins.exec}
        4    0.000    0.000    0.000    0.000 {built-in method builtins.len}
        1    0.000    0.000    0.000    0.000 {built-in method builtins.print}
        1    0.000    0.000    0.000    0.000 {built-in method io.open}
        1    0.000    0.000    0.000    0.000 {method '__exit__' of '_io._IOBase' objects}
        2    0.000    0.000    0.000    0.000 {method 'append' of 'list' objects}
    51182    0.011    0.000    0.011    0.000 {method 'decode' of 'bytes' objects}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
        1    0.001    0.001    0.001    0.001 {method 'encode' of 'str' objects}
    51183    0.012    0.000    0.012    0.000 {method 'find' of 'bytes' objects}
        1    0.001    0.001    0.003    0.003 {method 'read' of '_io.TextIOWrapper' objects}
```

</details>

which is ~500x improvement. The code does look a little bit harder to deal with than before, but I still hope this can be useful to iced.