### PR TITLE
Fixed type mismatch in `ns#alias_dict`

### DIFF
--- a/autoload/iced/nrepl/ns.vim
+++ b/autoload/iced/nrepl/ns.vim
@@ -206,6 +206,11 @@ function! iced#nrepl#ns#alias_dict(ns_name) abort
 
   if kondo.is_analyzed()
     let aliases = kondo.ns_aliases(a:ns_name)
+
+    if !aliases
+      return {}
+    endif
+
     for k in keys(aliases)
       if len(aliases[k]) > 0
         let aliases[k] = aliases[k][0]


### PR DESCRIPTION
Steps to reproduce
------------------

1. Enable kondo analysis in `vimrc`:

```vimscript
let g:iced_enable_clj_kondo_analysis = v:true
```

2. In vim, open any file of a clojure project (in my case it was a `deps.edn`, works with `*.clj` files too).
3. Start the repl with `iced repl`.
4. Connect vim to repl with `:IcedConnect`.
5. Press `o` to enter insert mode.

Expected behaviour
------------------

File changes instantly, no errors appear in repl window.

Actual behaviour
----------------

Vim hangs for a couple of seconds, an error shows up in a repl window:

```
ERROR: Unhandled REPL handler exception processing message {:id 11, :code {:paths ["src" "resources"]

 :deps {org.clojure/clojure {:mvn/version "1.11.1"}
        org.clojure/core.match {:mvn/version "1.0.1"}
        hiccup/hiccup {:mvn/version "1.0.5"}
        clj-http/clj-http {:mvn/version "3.12.3"}
        cheshire/cheshire {:mvn/version "5.11.0"}
        babashka/fs {:mvn/version "0.3.17"}
        }
 }, :session 7f423dcb-10de-4b5d-963c-8a2cff164019, :alias-map 0, :op iced-calculate-indent-level, :line-number 1}
java.lang.IllegalArgumentException: Don't know how to create ISeq from: java.lang.Long
	at clojure.lang.RT.seqFrom(RT.java:557)
	at clojure.lang.RT.seq(RT.java:537)
	at clojure.core$seq__5467.invokeStatic(core.clj:139)
	at clojure.core.protocols$seq_reduce.invokeStatic(protocols.clj:24)
	at clojure.core.protocols$fn__8226.invokeStatic(protocols.clj:75)
	at clojure.core.protocols$fn__8226.invoke(protocols.clj:75)
	at clojure.core.protocols$fn__8178$G__8173__8191.invoke(protocols.clj:13)
	at clojure.core$reduce.invokeStatic(core.clj:6886)
	at clojure.core$fn__8521.invokeStatic(core.clj:6888)
	at clojure.core$fn__8521.invoke(core.clj:6888)
	at clojure.core.protocols$fn__8257$G__8252__8266.invoke(protocols.clj:175)
	at clojure.core$reduce_kv.invokeStatic(core.clj:6919)
	at clojure.core$reduce_kv.invoke(core.clj:6910)
	at mrandersonicednrepl.medley.v1v4v0.medley.core$reduce_map.invokeStatic(core.cljc:87)
	at mrandersonicednrepl.medley.v1v4v0.medley.core$reduce_map.invoke(core.cljc:83)
	at mrandersonicednrepl.medley.v1v4v0.medley.core$map_keys.invokeStatic(core.cljc:105)
	at mrandersonicednrepl.medley.v1v4v0.medley.core$map_keys.invoke(core.cljc:102)
	at iced.nrepl.format$calcalate_indent_level.invokeStatic(format.clj:52)
	at iced.nrepl.format$calcalate_indent_level.invoke(format.clj:49)
	at iced.nrepl.format$iced_calculate_indent_level.invokeStatic(format.clj:115)
	at iced.nrepl.format$iced_calculate_indent_level.invoke(format.clj:102)
	at iced.nrepl$wrap_iced$fn__8165.invoke(nrepl.clj:50)
	at nrepl.middleware$wrap_conj_descriptor$fn__962.invoke(middleware.clj:16)
	at nrepl.server$default_handler$fn__1969.invoke(server.clj:141)
	at nrepl.server$handle_STAR_.invokeStatic(server.clj:24)
	at nrepl.server$handle_STAR_.invoke(server.clj:21)
	at nrepl.server$handle$fn__1937.invoke(server.clj:41)
	at clojure.core$binding_conveyor_fn$fn__5823.invoke(core.clj:2047)
	at clojure.lang.AFn.call(AFn.java:18)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1589)
```

Suggested solution
------------------

It appears, that `kondo.ns_aliases` may return `0`. I suppose that this case is equivalent to having no aliases, so it seems natural to handle the case and return `{}` instead.