### PR TITLE
Fix the exception by SyntaxWarning on Python 3.12

### DIFF
--- a/python/bencode.py
+++ b/python/bencode.py
@@ -117,8 +117,6 @@ def iced_vim_repr(x):
     '"\\\\"foo\\\\""'
     >>> iced_vim_repr('foo\\n')
     '"foo\\\\n"'
-    >>> iced_vim_repr('foo\d')
-    '"foo\\\\\\\\d"'
     >>> iced_vim_repr('foo\\d')
     '"foo\\\\\\\\d"'
     >>> iced_vim_repr(123)


### PR DESCRIPTION
This PR fix the error by `SyntaxWarning` on Python 3.12.

I got the following error using Python 3.12.

```
Error detected while processing function iced#repl#connect[7]..iced#nrepl#connect[9]..iced#nrepl#connect#auto[33]..<SNR>166___connect_selected[3]..<SNR>166___connect_nrepl[1]..iced#repl#connect[7]..iced#nrepl#connect[51]..iced#promise#sync[4]..function iced#repl#connect[7]..iced#nrepl#connect[9]..iced#nrepl#connect#auto[33]..<SNR>166___connect_sel
ected[3]..<SNR>166___connect_nrepl[1]..iced#repl#connect[7]..iced#nrepl#connect[51]..iced#promise#sync:
line    4:
E605: Exception not caught: {'throwpoint': 'function iced#repl#connect[7]..iced#nrepl#connect[9]..iced#nrepl#connect#auto[33]..<SNR>166___connect_selected[3]..<SNR>166___connect_nrepl[1]..iced#repl#connect[7]..iced#nrepl#connect[51]..iced#promise#sync[2]..iced#promise#call[5]..<SNR>212_new[5]..<lambda>13[1]..iced#nrepl#clone[2]..iced#nrepl#send[31
]..iced#system#get[21]..iced#component#bencode#start[2]..script /home/r6eve/repos/dotfiles/home_dot/.vim/plugged/vim-iced/autoload/iced/component/bencode/python.vim[5]..function provider#python3#Call[18]..script /home/r6eve/repos/dotfiles/home_dot/.vim/plugged/vim-iced/autoload/iced/component/bencode/python.vim, line 5', 'exception': 'Vim(return):
/home/r6eve/repos/dotfiles/home_dot/.vim/plugged/vim-iced/python/bencode.py:113: SyntaxWarning: invalid escape sequence ''\d'''}
```

This error is caused by `SyntaxWarning` introduced by Python 3.12 ( [docs](https://docs.python.org/3.12/whatsnew/3.12.html#other-language-changes) ).

```
# python --version
Python 3.12.3
# python
>>> 'foo\d'
<stdin>:1: SyntaxWarning: invalid escape sequence '\d'
'foo\\d'
```

And, referring to the docs,

>In a future Python version, SyntaxError will eventually be raised, instead of SyntaxWarning.

So, I decided to remove the warning codes without handling `SyntaxWarning` as be ignored.